### PR TITLE
Add support to Mooncake

### DIFF
--- a/SampleUserControlLibrary/SampleUserControl.xaml.cs
+++ b/SampleUserControlLibrary/SampleUserControl.xaml.cs
@@ -98,6 +98,12 @@ namespace SampleUserControlLibrary
             set;
         }
 
+        public string AzureEnvironment
+        {
+            get;
+            set;
+        }
+
         public SampleScenarios()
         {
             InitializeComponent();

--- a/SampleUserControlLibrary/SubscriptionKeyPage.xaml
+++ b/SampleUserControlLibrary/SubscriptionKeyPage.xaml
@@ -39,6 +39,11 @@
                 <Button Click="SaveKey_Click" Margin="5, 0, 0, 0" Padding="5, 0, 5, 0" VerticalAlignment="Center" >Save Key</Button>
                 <Button Click="DeleteKey_Click" Margin="5, 0, 0, 0" Padding="5, 0, 5, 0" VerticalAlignment="Center" >Delete Key</Button>
             </StackPanel>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top">
+                <Label VerticalAlignment="Center">Azure Environment:</Label>
+                <RadioButton GroupName="Environment" Margin="5, 0, 0, 0" Padding="5, 0, 5, 0" VerticalAlignment="Center" IsChecked="True" Checked="RadioButton_Checked">Global Azure</RadioButton>
+                <RadioButton GroupName="Environment" Margin="5, 0, 0, 0" Padding="5, 0, 5, 0" VerticalAlignment="Center" Checked="RadioButton_Checked">Mooncake - China Azure</RadioButton>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </Page>

--- a/SampleUserControlLibrary/SubscriptionKeyPage.xaml.cs
+++ b/SampleUserControlLibrary/SubscriptionKeyPage.xaml.cs
@@ -49,6 +49,7 @@ namespace SampleUserControlLibrary
         private readonly string _defaultSubscriptionKeyPromptMessage = "Paste your subscription key here to start";
 
         private static string s_subscriptionKey;
+        private static string s_environment;
 
         private SampleScenarios _sampleScenarios;
         public SubscriptionKeyPage(SampleScenarios sampleScenarios)
@@ -75,6 +76,23 @@ namespace SampleUserControlLibrary
                 s_subscriptionKey = value;
                 OnPropertyChanged<string>();
                 _sampleScenarios.SubscriptionKey = s_subscriptionKey;
+            }
+        }
+
+        /// <summary>
+        /// Get or sets Azure Environment
+        /// </summary>
+        public string AzureEnvironment
+        {
+            get
+            {
+                return s_environment;
+            }
+
+            set
+            {
+                s_environment = value;
+                _sampleScenarios.AzureEnvironment = s_environment;
             }
         }
 
@@ -185,6 +203,17 @@ namespace SampleUserControlLibrary
         private void GetKeyButton_Click(object sender, RoutedEventArgs e)
         {
             System.Diagnostics.Process.Start("https://www.microsoft.com/cognitive-services/en-us/sign-up");
+        }
+
+        private void RadioButton_Checked(object sender, RoutedEventArgs e)
+        {
+            var button = sender as RadioButton;
+
+            if (button.Content != null)
+            {
+                // s_environment = button.Content.ToString().ToLower();
+                AzureEnvironment = button.Content.ToString().ToLower();
+            }
         }
     }
 }


### PR DESCRIPTION
I add Radio buttons to let users to choose if they are working with
Global Azure or Mooncake. By default the Global Azure option is checked.

And the Add AzureEnvironment varible to differentiate it. This variable
will be used when creating service client since the service endpoints
are different from Global Azure and Mooncake.