### PR TITLE
Add common emotion classes

### DIFF
--- a/ClientLibrary/Contract/Emotion.cs
+++ b/ClientLibrary/Contract/Emotion.cs
@@ -39,14 +39,58 @@ using System.Threading.Tasks;
 
 namespace Microsoft.ProjectOxford.Common.Contract
 {
-    /// <summary>
-    /// Face object returned as part of the FaceDetection/EmotionRecognition operations.
-    /// </summary>
-    public class VideoFace
+    public class Emotion
     {
         /// <summary>
-        /// Gets or sets Id of face.
+        /// Gets or sets the face rectangle.
         /// </summary>
-        public int FaceId { get; set; }
+        /// <value>
+        /// The face rectangle.
+        /// </value>
+        public Rectangle FaceRectangle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the emotion scores.
+        /// </summary>
+        /// <value>
+        /// The emotion scores.
+        /// </value>
+        public EmotionScores Scores { get; set; }
+
+        #region overrides
+        public override bool Equals(object o)
+        {
+            if (o == null) return false;
+
+            var other = o as Emotion;
+
+            if (other == null) return false;
+
+            if (this.FaceRectangle == null)
+            {
+                if (other.FaceRectangle != null) return false;
+            }
+            else
+            {
+                if (!this.FaceRectangle.Equals(other.FaceRectangle)) return false;
+            }
+
+            if (this.Scores == null)
+            {
+                return other.Scores == null;
+            }
+            else
+            {
+                return this.Scores.Equals(other.Scores);
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            int r = (FaceRectangle == null) ? 0x33333333 : FaceRectangle.GetHashCode();
+            int s = (Scores == null) ? 0xccccccc : Scores.GetHashCode();
+            return r ^ s;
+        }
+        #endregion
     }
 }

--- a/ClientLibrary/Contract/EmotionScores.cs
+++ b/ClientLibrary/Contract/EmotionScores.cs
@@ -1,0 +1,133 @@
+﻿// 
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// 
+// Microsoft Cognitive Services (formerly Project Oxford): https://www.microsoft.com/cognitive-services
+// 
+// Microsoft Cognitive Services (formerly Project Oxford) GitHub:
+// https://github.com/Microsoft/Cognitive-Common-Windows
+// 
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+// 
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.ProjectOxford.Common.Contract
+{
+    ///
+    public class EmotionScores
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Anger { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Contempt { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Disgust { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Fear { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Happiness { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Neutral { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Sadness { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Surprise { get; set; }
+
+        /// <summary>
+        /// Create a sorted key-value pair of emotions and the corresponding scores, sorted from highest score on down.
+        /// To make the ordering stable, the score is the primary key, and the name is the secondary key.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, float>> ToRankedList()
+        {
+            return new Dictionary<string, float>()
+            {
+                { "Anger", Anger },
+                { "Contempt", Contempt },
+                { "Disgust", Disgust },
+                { "Fear", Fear },
+                { "Happiness", Happiness },
+                { "Neutral", Neutral },
+                { "Sadness", Sadness },
+                { "Surprise", Surprise }
+            }
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key)
+            .ToList();
+        }
+
+        #region overrides
+        public override bool Equals(object o)
+        {
+            if (o == null) return false;
+
+            var other = o as EmotionScores;
+            if (other == null) return false;
+
+            return this.Anger == other.Anger &&
+                this.Disgust == other.Disgust &&
+                this.Fear == other.Fear &&
+                this.Happiness == other.Happiness &&
+                this.Neutral == other.Neutral &&
+                this.Sadness == other.Sadness &&
+                this.Surprise == other.Surprise;
+        }
+
+        public override int GetHashCode()
+        {
+            return Anger.GetHashCode() ^
+                Disgust.GetHashCode() ^
+                Fear.GetHashCode() ^
+                Happiness.GetHashCode() ^
+                Neutral.GetHashCode() ^
+                Sadness.GetHashCode() ^
+                Surprise.GetHashCode();
+        }
+        #endregion;
+    }
+}

--- a/ClientLibrary/Microsoft.ProjectOxford.Common.csproj
+++ b/ClientLibrary/Microsoft.ProjectOxford.Common.csproj
@@ -38,6 +38,8 @@
   <ItemGroup>
     <Compile Include="ClientError.cs" />
     <Compile Include="ClientException.cs" />
+    <Compile Include="Contract\Emotion.cs" />
+    <Compile Include="Contract\EmotionScores.cs" />
     <Compile Include="Contract\VideoFace.cs" />
     <Compile Include="Contract\VideoFragment.cs" />
     <Compile Include="Contract\VideoOperation.cs" />


### PR DESCRIPTION
Add Emotion and Scores (as EmotionScores) classes from the emotion SDK as common contracts for use elsewhere in Cognitive services

Enables support for Microsoft/Cognitive-Face-Windows#18