### PR TITLE
Minor but breaking changes

### DIFF
--- a/ClientLibrary/ClientException.cs
+++ b/ClientLibrary/ClientException.cs
@@ -120,6 +120,7 @@ namespace Microsoft.ProjectOxford.Common
         /// <param name="error">The error entity.</param>
         /// <param name="httpStatus">The http status.</param>
         public ClientException(ClientError error, HttpStatusCode httpStatus)
+            : base(error?.Message)
         {
             this.Error = error;
             this.HttpStatus = httpStatus;

--- a/ClientLibrary/ServiceClient.cs
+++ b/ClientLibrary/ServiceClient.cs
@@ -169,7 +169,6 @@ namespace Microsoft.ProjectOxford.Common
         /// </summary>
         /// <typeparam name="TResponse">Type of response.</typeparam>
         /// <param name="apiUrl">API URL relative to the apiRoot</param>
-        /// <param name="requestBody">Content of the HTTP request.</param>
         /// <param name="cancellationToken">Async cancellation token</param>
         /// <returns>TResponse</returns>
         /// <exception cref="ClientException">Service exception</exception>

--- a/ClientLibrary/ServiceClient.cs
+++ b/ClientLibrary/ServiceClient.cs
@@ -150,7 +150,7 @@ namespace Microsoft.ProjectOxford.Common
 
         #region the JSON client
         /// <summary>
-        /// Helper method executing a GET REST request.
+        /// Helper method executing a POST REST request.
         /// </summary>
         /// <typeparam name="TRequest">Type of request.</typeparam>
         /// <typeparam name="TResponse">Type of response.</typeparam>
@@ -165,7 +165,7 @@ namespace Microsoft.ProjectOxford.Common
         }
 
         /// <summary>
-        /// Helper method executing a POST REST request.
+        /// Helper method executing a GET REST request.
         /// </summary>
         /// <typeparam name="TResponse">Type of response.</typeparam>
         /// <param name="apiUrl">API URL relative to the apiRoot</param>


### PR DESCRIPTION
A quick internet search reveals that the only property that derives from ServiceClient
on GitHub is the sunsetting Emotion API, so should mostly go unnoticed.

* Fix protected object name `UrlReqeust` to `UrlRequest`
* Expose the HttpClient instance to a derived class, giving it a chance to dispose it
* Beef up error handling to allow both old/new styles of error JSON.
* Drop the request body in the GetAsync method